### PR TITLE
Fix compatibility with Python 3.6 and its setup tools

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,15 +30,7 @@ Supported versions
     :alt: Build Status
 
 - Django 1.9, 1.10
-- Python 3.2, 3.3, 3.4, 3.5 
-
-Installation
-============
-
-.. code:: bash
-
-    $ pip install -e git+https://github.com/bjarnoldus/django-roa.git@master#egg=django_roa
-
+- Python 3.2, 3.3, 3.4, 3.5, 3.6
 
 Fork getting started
 ====================

--- a/django_roa.egg-info/PKG-INFO
+++ b/django_roa.egg-info/PKG-INFO
@@ -1,12 +1,12 @@
 Metadata-Version: 1.1
 Name: django-roa
-Version: 1.8.56
+Version: 2.0.16
 Summary: Turn your models into remote resources that you can access through Django's ORM.
-Home-page: https://github.com/bjarnoldus/django-roa
-Author: David Larlet
-Author-email: david@larlet.fr
+Home-page: https://github.com/Keypr/django-roa
+Author: Jeroen Arnoldus
+Author-email: jeroen@repleo.nl
 License: BSD
-Download-URL: https://github.com/bjarnoldus/django-roa/archive/master.zip
+Download-URL: https://github.com/Keypr/django-roa/archive/master.zip
 Description: UNKNOWN
 Platform: UNKNOWN
 Classifier: Development Status :: 4 - Beta

--- a/django_roa.egg-info/requires.txt
+++ b/django_roa.egg-info/requires.txt
@@ -2,3 +2,5 @@ Django
 requests
 simplejson
 djangorestframework
+djangorestframework-xml
+djangorestframework-yaml

--- a/django_roa.egg-info/top_level.txt
+++ b/django_roa.egg-info/top_level.txt
@@ -1,2 +1,2 @@
-examples
 django_roa
+examples

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
     ],
     install_requires=requires,
-    tests_require={
-        'Piston-tests': ['django-piston'],
-    }
+    tests_require=[
+        'django-piston',
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,10 @@ else:
     ]
 
 setup(
-    name='django-roa',
-    version='2.0.13',
-    url='https://github.com/bjarnoldus/django-roa',
-    download_url='https://github.com/bjarnoldus/django-roa/archive/master.zip',
+    name='django-roa-kpr',
+    version='2.0.16',
+    url='https://github.com/Keypr/django-roa',
+    download_url='https://github.com/Keypr/django-roa/archive/master.zip',
     license='BSD',
     description="Turn your models into remote resources that you can access through Django's ORM.",
     author='Jeroen Arnoldus',


### PR DESCRIPTION
When I ran one of our services setup, I faced with the following error.

```
Collecting django-roa-kpr==2.0.15 (from -r requirements.txt (line 34))
  Downloading ...
    Complete output from command python setup.py egg_info:
    error in django-roa-kpr setup command: 'tests_require' must be a string or list of strings containing valid project/version requirement specifiers; Unordered types are not allowed
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/hf/fy08y8kj5bbcs98vzq2zq3j80000gn/T/pip-install-77hxjx7q/django-roa-kpr/
```

The fix is available in the upstream repo. ddeed29
This PR adds the fix and also fixes `setup.py`, so we can properly publish the module to our internal Pypi repository.