### PR TITLE
[CORE-5265] Fix for prefetching

### DIFF
--- a/django_roa.egg-info/PKG-INFO
+++ b/django_roa.egg-info/PKG-INFO
@@ -1,12 +1,12 @@
 Metadata-Version: 1.1
 Name: django-roa
-Version: 2.0.17
+Version: 2.0.18
 Summary: Turn your models into remote resources that you can access through Django's ORM.
-Home-page: https://github.com/Keypr/django-roa
+Home-page: https://github.com/Intelity/django-roa
 Author: Jeroen Arnoldus
 Author-email: jeroen@repleo.nl
 License: BSD
-Download-URL: https://github.com/Keypr/django-roa/archive/master.zip
+Download-URL: https://github.com/Intelity/django-roa/archive/master.zip
 Description: UNKNOWN
 Platform: UNKNOWN
 Classifier: Development Status :: 4 - Beta

--- a/django_roa/db/query.py
+++ b/django_roa/db/query.py
@@ -242,7 +242,7 @@ class RemoteQuerySet(query.QuerySet):
 
         self.params = {}
 
-        self._prefetch_related_lookups = False
+        self._prefetch_related_lookups = ()
 
     ########################
     # PYTHON MAGIC METHODS #

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,9 @@ else:
 
 setup(
     name='django-roa-kpr',
-    version='2.0.17',
-    url='https://github.com/Keypr/django-roa',
-    download_url='https://github.com/Keypr/django-roa/archive/master.zip',
+    version='2.0.18',
+    url='https://github.com/Intelity/django-roa',
+    download_url='https://github.com/Intelity/django-roa/archive/master.zip',
     license='BSD',
     description="Turn your models into remote resources that you can access through Django's ORM.",
     author='Jeroen Arnoldus',


### PR DESCRIPTION
This fix allows prefetching for a `RemoteQuerySet`. Currently it's failing with an error `TypeError: 'bool' object is not iterable` because the `_prefetch_related_lookups` attribute is a boolean instead of an iterable like in Django: https://github.com/django/django/blob/3259983f569151232d8e3b0c3d0de3a858c2b265/django/db/models/query.py#L195